### PR TITLE
Fix childs

### DIFF
--- a/src/Analyzer/Adapter/ASTNode.ts
+++ b/src/Analyzer/Adapter/ASTNode.ts
@@ -1,5 +1,5 @@
 export interface ASTNode {
-  getChilds(): ASTNode[];
+  getChildren(): ASTNode[];
   isFunction(): boolean;
   isFauxClass(): boolean;
   isMethod(): boolean;

--- a/src/Analyzer/ClassMethodFunctionFauxClass/Analyzer.ts
+++ b/src/Analyzer/ClassMethodFunctionFauxClass/Analyzer.ts
@@ -13,7 +13,9 @@ export class Analyzer<T, K> {
 
   analyze(rootASTNode: ASTNode): K {
     const result: CodeMetrics<T>[] = [];
-    const classesNodes = rootASTNode.getChilds().filter((row) => row.isClass());
+    const classesNodes = rootASTNode
+      .getChildren()
+      .filter((row) => row.isClass());
     const functionNodes = this.extractFunctionAndMethodNode(rootASTNode);
     const fauxNodes = functionNodes.filter((row) => row.isFauxClass());
     const pureFunctionNodes = functionNodes.filter((row) => !row.isFauxClass());
@@ -43,7 +45,7 @@ export class Analyzer<T, K> {
       },
     ];
 
-    return [...astNode.getChilds()]
+    return [...astNode.getChildren()]
       .flatMap((row) => this.extractFunctionAndMethodNode(row))
       .map((row) => this.createMethod(row, codeStructures));
   }
@@ -76,7 +78,7 @@ export class Analyzer<T, K> {
 
     return result.concat(
       ...astNode
-        .getChilds()
+        .getChildren()
         .map((row) => this.extractFunctionAndMethodNode(row))
     );
   }

--- a/src/Analyzer/SourceFile/__tests__/Analayzer.test.ts
+++ b/src/Analyzer/SourceFile/__tests__/Analayzer.test.ts
@@ -22,7 +22,7 @@ describe('Source file analyzer class', () => {
       getName: () => '',
       getStartLineNumber: () => 0,
       getEndLineNumber: () => 0,
-      getChilds: () => [],
+      getChildren: () => [],
     });
 
     expect(actual.dummy).toBe(2);

--- a/src/Calculator/CognitiveComplexity/Adapter/ComplexityCountableNode.ts
+++ b/src/Calculator/CognitiveComplexity/Adapter/ComplexityCountableNode.ts
@@ -2,5 +2,5 @@ export interface ComplexityCountableNode {
   isIncrement(): boolean;
   isNestLevelUp(): boolean;
   isNestingIncrement(): boolean;
-  getChilds(): ComplexityCountableNode[];
+  getChildren(): ComplexityCountableNode[];
 }

--- a/src/Calculator/CognitiveComplexity/Calculator.ts
+++ b/src/Calculator/CognitiveComplexity/Calculator.ts
@@ -23,14 +23,14 @@ export class Calculator {
       const incrementedNest = nest + 1;
       return result.concat(
         ...node
-          .getChilds()
+          .getChildren()
           .map((row) => this.extractComplexity(row, incrementedNest))
           .filter((row) => row.length > 0)
       );
     }
 
     return result.concat(
-      ...node.getChilds().map((row) => this.extractComplexity(row, nest))
+      ...node.getChildren().map((row) => this.extractComplexity(row, nest))
     );
   }
 }

--- a/src/Calculator/CognitiveComplexity/__tests__/Calculator.test.ts
+++ b/src/Calculator/CognitiveComplexity/__tests__/Calculator.test.ts
@@ -20,7 +20,7 @@ describe('Cognitive Complexity Calculator', () => {
       const actual = calculator.calculate(
         new ComplexityCountableNode({
           DSL: '',
-          childs: [{ DSL: 'I' }],
+          children: [{ DSL: 'I' }],
         })
       );
 
@@ -31,7 +31,7 @@ describe('Cognitive Complexity Calculator', () => {
       const actual = calculator.calculate(
         new ComplexityCountableNode({
           DSL: 'N',
-          childs: [{ DSL: 'I' }],
+          children: [{ DSL: 'I' }],
         })
       );
 
@@ -42,7 +42,7 @@ describe('Cognitive Complexity Calculator', () => {
       const actual = calculator.calculate(
         new ComplexityCountableNode({
           DSL: 'N',
-          childs: [{ DSL: 'IN' }],
+          children: [{ DSL: 'IN' }],
         })
       );
 

--- a/src/Calculator/CognitiveComplexity/__tests__/Complexity.test.ts
+++ b/src/Calculator/CognitiveComplexity/__tests__/Complexity.test.ts
@@ -38,5 +38,5 @@ const createDummyNode = (DSL: string) => ({
   isIncrement: () => DSL.includes('I'),
   isNestLevelUp: () => DSL.includes('N'),
   isNestingIncrement: () => DSL.includes('I') && DSL.includes('N'),
-  getChilds: () => [],
+  getChildren: () => [],
 });

--- a/src/Calculator/CognitiveComplexity/__tests__/ComplexityStore.test.ts
+++ b/src/Calculator/CognitiveComplexity/__tests__/ComplexityStore.test.ts
@@ -40,5 +40,5 @@ const createDummyNode = (DSL: string) => ({
   isIncrement: () => DSL.includes('I'),
   isNestLevelUp: () => DSL.includes('N'),
   isNestingIncrement: () => DSL.includes('I') && DSL.includes('N'),
-  getChilds: () => [],
+  getChildren: () => [],
 });

--- a/src/Calculator/Halstead/Adapter/HalsteadCountableNode.ts
+++ b/src/Calculator/Halstead/Adapter/HalsteadCountableNode.ts
@@ -1,6 +1,6 @@
 export interface HalsteadCountableNode {
   isOperand(): boolean;
   isOperator(): boolean;
-  getChilds(): HalsteadCountableNode[];
+  getChildren(): HalsteadCountableNode[];
   getText(): string;
 }

--- a/src/Calculator/Halstead/Calculator.ts
+++ b/src/Calculator/Halstead/Calculator.ts
@@ -21,7 +21,7 @@ export class Calculator {
     }
 
     result = result.concat(
-      ...node.getChilds().map((row) => this.extractOperandsAndOperators(row))
+      ...node.getChildren().map((row) => this.extractOperandsAndOperators(row))
     );
 
     return result;

--- a/src/Calculator/Halstead/__tests__/Calculator.test.ts
+++ b/src/Calculator/Halstead/__tests__/Calculator.test.ts
@@ -22,7 +22,7 @@ describe('Halstead Calculator', () => {
         new HalsteadCountableNode({
           DSL: '',
           text: 'Dummy',
-          childs: [{ DSL: 'N', text: 'Dummy' }],
+          children: [{ DSL: 'N', text: 'Dummy' }],
         })
       );
 
@@ -34,7 +34,7 @@ describe('Halstead Calculator', () => {
         new HalsteadCountableNode({
           DSL: 'N',
           text: 'dummy',
-          childs: [{ DSL: 'N', text: 'dummy' }],
+          children: [{ DSL: 'N', text: 'dummy' }],
         })
       );
 
@@ -57,7 +57,7 @@ describe('Halstead Calculator', () => {
         new HalsteadCountableNode({
           DSL: '',
           text: 'Dummy',
-          childs: [{ DSL: 'T', text: 'Dummy' }],
+          children: [{ DSL: 'T', text: 'Dummy' }],
         })
       );
 
@@ -69,7 +69,7 @@ describe('Halstead Calculator', () => {
         new HalsteadCountableNode({
           DSL: 'T',
           text: 'dummy',
-          childs: [{ DSL: 'T', text: 'dummy' }],
+          children: [{ DSL: 'T', text: 'dummy' }],
         })
       );
 
@@ -84,12 +84,12 @@ describe('Halstead Calculator', () => {
         new HalsteadCountableNode({
           DSL: 'T',
           text: 'dummy',
-          childs: [
+          children: [
             { DSL: 'N', text: 'operator' },
             {
               DSL: 'N',
               text: 'operator',
-              childs: [
+              children: [
                 { DSL: 'T', text: 'operand' },
                 { DSL: 'T', text: 'operand' },
               ],

--- a/src/Language/TypeScript/ASTNode.ts
+++ b/src/Language/TypeScript/ASTNode.ts
@@ -58,7 +58,7 @@ export class ASTNode implements ASTNodeInterface {
 
     return (
       new ASTNode((<ts.FunctionExpression>this.node).body, this.sourceFile)
-        .getChilds()
+        .getChildren()
         .filter(
           (row) =>
             new ComplexityCountableNode(row).isIncrement() && !row.isFunction()
@@ -153,7 +153,7 @@ export class ASTNode implements ASTNodeInterface {
     return result;
   }
 
-  getChilds() {
+  getChildren() {
     const result: ts.Node[] = [];
     ts.forEachChild(this.node, (row) => {
       result.push(row);

--- a/src/Language/TypeScript/ComplexityCountableNode.ts
+++ b/src/Language/TypeScript/ComplexityCountableNode.ts
@@ -81,9 +81,9 @@ export class ComplexityCountableNode
     );
   }
 
-  getChilds() {
+  getChildren() {
     return this.node
-      .getChilds()
+      .getChildren()
       .map((node) => new ComplexityCountableNode(node));
   }
 }

--- a/src/Language/TypeScript/HalsteadCountableNode.ts
+++ b/src/Language/TypeScript/HalsteadCountableNode.ts
@@ -59,7 +59,7 @@ export class HalsteadCountableNode implements HalsteadCountableNodeInterface {
     return '';
   }
 
-  getChilds() {
-    return this.node.getChilds().map((row) => new HalsteadCountableNode(row));
+  getChildren() {
+    return this.node.getChildren().map((row) => new HalsteadCountableNode(row));
   }
 }

--- a/src/Language/TypeScript/__tests__/ASTNode.test.ts
+++ b/src/Language/TypeScript/__tests__/ASTNode.test.ts
@@ -96,7 +96,7 @@ describe('ASTNode', () => {
     });
   });
 
-  describe('.getChilds()', () => {
+  describe('.getChildren()', () => {
     it('should get children ASTNode.', () => {
       const sourceFile = ts.createSourceFile(
         'dummy.ts',
@@ -106,7 +106,7 @@ describe('ASTNode', () => {
       );
 
       const classStructure = new ASTNode(sourceFile.statements[0], sourceFile);
-      const actual = classStructure.getChilds();
+      const actual = classStructure.getChildren();
 
       expect(actual.length).toBe(3);
       expect(actual[1]).toBeInstanceOf(ASTNode);

--- a/src/Sabik/Analyzer/__tests__/Analyzer.test.ts
+++ b/src/Sabik/Analyzer/__tests__/Analyzer.test.ts
@@ -12,7 +12,7 @@ describe('Analyzer', () => {
       convert: (_) =>
         new ComplexityCountableNode({
           DSL: 'IN',
-          childs: [{ DSL: 'I' }, { DSL: '' }],
+          children: [{ DSL: 'I' }, { DSL: '' }],
         }),
     },
     halsteadConverter: {

--- a/src/Sabik/Analyzer/__tests__/Analyzer.test.ts
+++ b/src/Sabik/Analyzer/__tests__/Analyzer.test.ts
@@ -20,7 +20,7 @@ describe('Analyzer', () => {
         new HalsteadCountableNode({
           DSL: 'T',
           text: '+',
-          childs: [
+          children: [
             { DSL: 'N', text: '1' },
             { DSL: '', text: 'dummy' },
           ],

--- a/src/Sabik/Analyzer/__tests__/MetricsAnalyzer.test.ts
+++ b/src/Sabik/Analyzer/__tests__/MetricsAnalyzer.test.ts
@@ -16,7 +16,7 @@ describe('MetricsAnalyzer', () => {
         convert: (_) =>
           new ComplexityCountableNode({
             DSL: 'IN',
-            childs: [{ DSL: 'I' }, { DSL: '' }],
+            children: [{ DSL: 'I' }, { DSL: '' }],
           }),
       },
       {

--- a/src/Sabik/Analyzer/__tests__/MetricsAnalyzer.test.ts
+++ b/src/Sabik/Analyzer/__tests__/MetricsAnalyzer.test.ts
@@ -24,7 +24,7 @@ describe('MetricsAnalyzer', () => {
           new HalsteadCountableNode({
             DSL: 'T',
             text: '+',
-            childs: [
+            children: [
               { DSL: 'N', text: '1' },
               { DSL: '', text: 'dummy' },
             ],

--- a/src/Sabik/__tests__/Sabik.test.ts
+++ b/src/Sabik/__tests__/Sabik.test.ts
@@ -20,7 +20,7 @@ describe('Sabik', () => {
           convert: (_) =>
             new ComplexityCountableNode({
               DSL: 'IN',
-              childs: [{ DSL: 'I' }, { DSL: '' }],
+              children: [{ DSL: 'I' }, { DSL: '' }],
             }),
         },
         halsteadConverter: {

--- a/src/Sabik/__tests__/Sabik.test.ts
+++ b/src/Sabik/__tests__/Sabik.test.ts
@@ -28,7 +28,7 @@ describe('Sabik', () => {
             new HalsteadCountableNode({
               DSL: 'T',
               text: '+',
-              childs: [
+              children: [
                 { DSL: 'N', text: '1' },
                 { DSL: '', text: 'dummy' },
               ],

--- a/src/TestHelpers/ASTNode.ts
+++ b/src/TestHelpers/ASTNode.ts
@@ -45,7 +45,7 @@ export class ASTNode {
     return this.endLine;
   }
 
-  getChilds() {
+  getChildren() {
     return Object.keys(this.childs).map(
       (keyName) => new ASTNode(keyName, this.childs[keyName])
     );

--- a/src/TestHelpers/ASTNode.ts
+++ b/src/TestHelpers/ASTNode.ts
@@ -5,16 +5,16 @@ export class ASTNode {
   private startLine: number = 0;
   private endLine: number = 0;
   private name: string;
-  private childs: NodeSource;
+  private children: NodeSource;
 
-  constructor(DSL: string, childs: NodeSource = {}) {
+  constructor(DSL: string, children: NodeSource = {}) {
     const [structureType, name, startLine, endLine] = DSL.split(':', 4);
 
     this.structureType = structureType;
     this.name = name;
     this.startLine = Number(startLine);
     this.endLine = Number(endLine);
-    this.childs = childs;
+    this.children = children;
   }
 
   isClass() {
@@ -46,8 +46,8 @@ export class ASTNode {
   }
 
   getChildren() {
-    return Object.keys(this.childs).map(
-      (keyName) => new ASTNode(keyName, this.childs[keyName])
+    return Object.keys(this.children).map(
+      (keyName) => new ASTNode(keyName, this.children[keyName])
     );
   }
 }

--- a/src/TestHelpers/ComplexityCountableNode.ts
+++ b/src/TestHelpers/ComplexityCountableNode.ts
@@ -1,15 +1,15 @@
 type Config = {
   DSL: string;
-  childs?: Config[];
+  children?: Config[];
 };
 
 export class ComplexityCountableNode {
   private DSL: string;
-  private childs: Config[];
+  private children: Config[];
 
-  constructor({ DSL, childs = [] }: Config) {
+  constructor({ DSL, children = [] }: Config) {
     this.DSL = DSL;
-    this.childs = childs;
+    this.children = children;
   }
 
   isIncrement() {
@@ -24,7 +24,7 @@ export class ComplexityCountableNode {
     return this.DSL.includes('I') && this.DSL.includes('N');
   }
 
-  getChilds() {
-    return this.childs.map((config) => new ComplexityCountableNode(config));
+  getChildren() {
+    return this.children.map((config) => new ComplexityCountableNode(config));
   }
 }

--- a/src/TestHelpers/HalsteadCountableNode.ts
+++ b/src/TestHelpers/HalsteadCountableNode.ts
@@ -27,7 +27,7 @@ export class HalsteadCountableNode {
     return this.text;
   }
 
-  getChilds() {
+  getChildren() {
     return this.childs.map((config) => new HalsteadCountableNode(config));
   }
 }

--- a/src/TestHelpers/HalsteadCountableNode.ts
+++ b/src/TestHelpers/HalsteadCountableNode.ts
@@ -1,18 +1,18 @@
 type Config = {
   DSL: string;
   text: string;
-  childs?: Config[];
+  children?: Config[];
 };
 
 export class HalsteadCountableNode {
   private DSL: string;
   private text: string;
-  private childs: Config[];
+  private children: Config[];
 
-  constructor({ DSL, text, childs = [] }: Config) {
+  constructor({ DSL, text, children = [] }: Config) {
     this.DSL = DSL;
     this.text = text;
-    this.childs = childs;
+    this.children = children;
   }
 
   isOperator() {
@@ -28,6 +28,6 @@ export class HalsteadCountableNode {
   }
 
   getChildren() {
-    return this.childs.map((config) => new HalsteadCountableNode(config));
+    return this.children.map((config) => new HalsteadCountableNode(config));
   }
 }


### PR DESCRIPTION
`childs` is nonstandard.

> Primarily used in dialogue, to indicate that a foreign or illiterate speaker has a poor grasp of the English language.
https://en.wiktionary.org/wiki/childs
