### PR TITLE
Add GitHub Actions documentation for sabik

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,25 @@
+# Using sabik with GitHub Actions
+
+This document explains how to use sabik in GitHub Actions to generate code metrics badges.
+
+## Setup GitHub Actions
+
+Create a workflow file:
+
+.github/workflows/build.yml
+
+## Run sabik
+
+Run sabik to generate metrics.
+
+./bin/run ./src -t JSON
+
+## Generated Metrics
+
+- LogicalLineOfCode
+- CognitiveComplexity
+- Maintainability
+
+## Badge generation
+
+Badges can be generated using dynamic-badges-action.

--- a/index.md
+++ b/index.md
@@ -43,9 +43,9 @@ OPTIONS
 
 # Support Programming Language
 
-* TypeScript
-* JavaScript
-* PHP < 8.0
+- TypeScript
+- JavaScript
+- PHP < 8.0
 
 For now.
 
@@ -53,10 +53,10 @@ For now.
 
 Sabik analyzable metrics are following.
 
-* Cognitive Complexity
-* Halstead complexity measures
-* Line of Code(Logical, Physical)
-* Maintainability
+- Cognitive Complexity
+- Halstead complexity measures
+- Line of Code(Logical, Physical)
+- Maintainability
 
 For now.
 
@@ -99,15 +99,15 @@ This metric ranges from 0 ~ 100.
 It’s maintenance hard when under 60 scores. (In my experience)
 This metrics is normally using the following, calculate.
 
-* Line of Code
-* Halstead metrics
-* Cyclomatic Complexity
+- Line of Code
+- Halstead metrics
+- Cyclomatic Complexity
 
 But in Sabik using following.
 
-* Line of Code
-* Halstead metrics
-* Cognitive Complexity
+- Line of Code
+- Halstead metrics
+- Cognitive Complexity
 
 If you want to know more about the detail, please see the following.
 


### PR DESCRIPTION
This PR adds documentation explaining how to use sabik in GitHub Actions
to generate source code metrics badges.

Documentation is written in Markdown and targets the gh-pages branch.